### PR TITLE
Check for Url and add Source action

### DIFF
--- a/Source/Marvirc/Action/Mention/HackBook.php
+++ b/Source/Marvirc/Action/Mention/HackBook.php
@@ -2,7 +2,13 @@
 
 namespace Marvirc\Action\Mention {
 
+use Marvirc\Url;
+use Hoa\Http\Response\Response;
+
 class HackBook implements \Marvirc\Action\IAction {
+
+
+    protected static $hostname = 'hoa-project.net';
 
     public static function getPattern ( ) {
 
@@ -22,13 +28,19 @@ class HackBook implements \Marvirc\Action\IAction {
         $subject = str_replace('\\', '/', $matches['subject']);
 
         if(false !== strpos($subject, '/'))
-            list(, $libray) = explode('/', $subject);
+            list(, $library) = explode('/', $subject);
         else
             $library = $subject;
 
-        return 'http://hoa-project.net/' .
-               (isset($matches['lang']) ? ucfirst(strtolower($matches['lang'])) . '/' : '') .
-               'Literature/Hack/' . ucfirst(strtolower($library)) . '.html';
+        $path = (isset($matches['lang']) ? ucfirst(strtolower($matches['lang'])) . '/' : '') .
+            'Literature/Hack/' . ucfirst(strtolower($library)) . '.html';
+
+        $url = 'http://' . static::$hostname . '/' . $path;
+
+        $code = Url::checkUrl($url);
+
+        return (Response::STATUS_OK === $code
+            || Response::STATUS_MOVED_PERMANENTLY === $code) ? $url : Url::getErrorMessage();
     }
 }
 

--- a/Source/Marvirc/Action/Mention/SourceCode.php
+++ b/Source/Marvirc/Action/Mention/SourceCode.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Marvirc\Action\Mention {
+
+use Marvirc\Url;
+use Hoa\Http\Response\Response;
+
+class SourceCode implements \Marvirc\Action\IAction {
+
+    public static function getPattern ( ) {
+
+        return '#\bsource\s+(?<library>[\w\-/\?\.=\\\\]+)(?:\s+(?<parameters>[\w-/?.=\#]+))?#i';
+    }
+
+    public static function getUsage ( ) {
+
+        return 'Get link to a source code. Use keywords "source" followed by class or path';
+    }
+
+    public static function compute ( Array $data ) {
+
+        $extension  = null;
+        $parameters = null;
+
+        $pattern = static::getPattern();
+        preg_match($pattern, $data['message'], $matches);
+
+        if (false !== strpos($matches['library'], '\\')) {
+            $matches['library'] = str_replace('\\', '/', $matches['library']);
+            $matches['library'] = str_replace('Hoa', 'Library', $matches['library']);
+
+            if (2 < count(preg_split('#/#', $matches['library'], null, PREG_SPLIT_NO_EMPTY))) {
+                $extension = '.php';
+            }
+        }
+
+        $matches['library'] = trim(str_replace('//', '/', $matches['library']), '/');
+
+        $url = 'http://central.hoa-project.net/Resource/' . ucfirst($matches['library']);
+
+        if (isset($matches['parameters'])) {
+            $parameters = ucfirst($matches['parameters']);
+        }
+
+        $url .= $parameters . $extension;
+
+        $code = Url::checkUrl($url);
+
+        return (Response::STATUS_OK === $code
+            || Response::STATUS_MOVED_PERMANENTLY === $code) ? $url : Url::getErrorMessage();
+    }
+}
+
+}

--- a/Source/Marvirc/Action/PrivateMessage/SourceCode.php
+++ b/Source/Marvirc/Action/PrivateMessage/SourceCode.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Marvirc\Action\PrivateMessage {
+
+class SourceCode extends \Marvirc\Action\Mention\SourceCode { }
+
+}

--- a/Source/Marvirc/Url.php
+++ b/Source/Marvirc/Url.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Marvirc {
+
+use Hoa\Socket\Client;
+use Hoa\Http\Response\Response;
+use Hoa\Http\Request;
+
+class Url {
+
+    /**
+     * @var string contains error message for code
+     */
+    protected static $errorMessage;
+
+    /**
+     * getErrorMessage
+     *
+     * @static
+     * @access public
+     * @return string
+     */
+    public static function getErrorMessage()
+    {
+        return static::$errorMessage;
+    }
+
+    /**
+     * check Make a request to url and define which return code
+     * set static error properties to display error during the process
+     *
+     * @param string $url
+     * @static
+     * @access public
+     * @return string
+     */
+    public static function checkUrl($url) {
+        $url = parse_url($url);
+
+        $client = new Client('tcp://'. $url['host'] . ':80');
+        $client->connect();
+
+        if ('https' === $url['scheme']) {
+            $client->setEncryption(true, Client::ENCRYPTION_TLS);
+        }
+
+        $request = new Request();
+        $request->setMethod($request::METHOD_GET);
+        $request->setUrl($url['path']);
+
+        $request['Host']       = $url['host'];
+        $request['Connection'] = 'close';
+
+        $client->writeAll($request);
+
+        $response = new Response(false);
+        $response->parse($client->readAll());
+
+        $client->close();
+
+        switch ($response['status']) {
+            case Response::STATUS_OK:
+            case Response::STATUS_MOVED_PERMANENTLY:
+                break;
+            case Response::STATUS_FORBIDDEN:
+            case Response::STATUS_NOT_FOUND:
+            case Response::STATUS_INTERNAL_SERVER_ERROR:
+                static::$errorMessage = $response['status'];
+                break;
+            default:
+                static::$errorMessage = 'Error while getting status code!';
+                break;
+        }
+
+        return $response['status'];
+    }
+}
+
+}

--- a/composer.json
+++ b/composer.json
@@ -3,8 +3,10 @@
         "hoa/console"   : "dev-master",
         "hoa/dispatcher": "dev-master",
         "hoa/file"      : "dev-master",
+        "hoa/http"      : "dev-master",
         "hoa/irc"       : "dev-master",
         "hoa/router"    : "dev-master",
+        "hoa/socket"    : "dev-master",
         "hoa/websocket" : "dev-master"
     },
     "minimum-stability": "dev"


### PR DESCRIPTION
2 steps here

First of all, this patch fixe a potentially bug with library and add a way to check the response of Uri to define if we display a link or an error.

In second time, this patch allow to use source as a keyword when the bot ins mention to get Uri for source code. You need to use class or path.

Example

``` bash
Marvirc: source Hoa\Websocket
Marvirc: source Hoa\Websocket\Server
Marvirc: source Hoa/Websocket/Server.php
```
