### PR TITLE
Add keywords for Marvirc actions

### DIFF
--- a/Source/Marvirc/Bin/Join.php
+++ b/Source/Marvirc/Bin/Join.php
@@ -195,6 +195,21 @@ class Join extends Console\Dispatcher\Kit {
             return;
         });
 
+        // Message.
+        $client->on('message', function ( $bucket ) use ( $self ) {
+
+            $data   = $bucket->getData();
+            $answer = null;
+
+            if(0 !== preg_match('/!(?=\b)/', $data['message']))
+                $answer = $self->getAnswer('Mention', $data, null);
+
+            if(null !== $answer)
+                $bucket->getSource()->say($answer);
+
+            return;
+        });
+
         // Here we go.
         $group->run();
 


### PR DESCRIPTION
Marvirc will take into consideration two keywords:

* `!hack`
* `!source`

Now, it's not necessary to call Marvirc if you want information about url for hackbook or source code.

exemple:
```
Hey man, go to !source Hoa\Compiler
```
or
```
You can read !hack Compiler
```